### PR TITLE
Fix SPSS labeled missing in two vars

### DIFF
--- a/sections/week4/home.Rmd
+++ b/sections/week4/home.Rmd
@@ -381,7 +381,7 @@ select(ess, trstlgl:rfgbfml) %>% descriptives()
   provided an answer of 77 on a 10-point scale.
 
 ```{r}
-ess %>%
+ess <- ess %>%
   mutate(across(c(qfimchr, qfimwht), na_if, 77)) %>% 
   mutate(across(c(qfimchr, qfimwht), na_if, 88)) %>%
   mutate(across(c(qfimchr, qfimwht), na_if, 99))

--- a/sections/week4/home.Rmd
+++ b/sections/week4/home.Rmd
@@ -371,7 +371,21 @@ select(ess, trstlgl:rfgbfml) %>% descriptives()
   <details>
     <summary>Click for explanation</summary>
   
-  No. Everything looks pretty much fine.
+  The variables `qfimchr` and `qfimwht` both contain values that fall outside the expected
+  range for our survey responses: 77, 88, and 99. In SPSS, these were labeled as "Refusal"
+  "Don't know" and "No answer" respectively, and would not have contributed to the
+  analysis. 
+
+  Here, we need to tell R that these values should be considered missing, or `NA`.
+  Otherwise they will contribute the numeric value to the analysis, as though someone had
+  provided an answer of 77 on a 10-point scale.
+
+```{r}
+ess %>%
+  mutate(across(c(qfimchr, qfimwht), na_if, 77)) %>% 
+  mutate(across(c(qfimchr, qfimwht), na_if, 88)) %>%
+  mutate(across(c(qfimchr, qfimwht), na_if, 99))
+```
 
 </details>
 


### PR DESCRIPTION
Can also go into the graphical section in the section immediately preceding. Vars qfimchr and qfimwht, under the current pipeline, don't have their SPSS labeled missingness converted to NA. 

ess %>%
  mutate(across(c(qfimchr, qfimwht), na_if, 77)) %>% 
  mutate(across(c(qfimchr, qfimwht), na_if, 88)) %>%
  mutate(across(c(qfimchr, qfimwht), na_if, 99))